### PR TITLE
apply ascii encoding fix to print_pr

### DIFF
--- a/github-pr
+++ b/github-pr
@@ -40,7 +40,7 @@ def _print_pr(pr, **args):
     if args['numberonly']:
         print "%d" % pr.number
     else:
-        print "#%d [%s] %10s <- %-30s    %s" % (pr.number, pr.state, pr.base.ref, pr.head.ref, pr.title)
+        print "#%d [%s] %10s <- %-30s    %s" % (pr.number, pr.state, pr.base.ref, pr.head.ref, pr.title.encode('ascii', errors='ignore'))
         if 'matching_files' in args:
             for f in args['matching_files']:
                 print f


### PR DESCRIPTION
Apply ascii encoding fix to print_pr method. Fix already existed for _print_pr_tables https://github.com/scarrera/github-pr/blob/b620d9dd0aaca4b7985e6900d56586c34ed19e5b/github-pr#L33