### PR TITLE
Dev splitout main

### DIFF
--- a/github_pr.py
+++ b/github_pr.py
@@ -158,7 +158,9 @@ def github_update_pr(**args):
     if was_not_updated:
         print "Warning: PR %d was NOT updated, no title or body to edit provided" % args['number']
 
-if __name__ == '__main__':
+def main():
+    """ For executing as a script. """
+
     default_token = os.getenv('GITHUB_API_TOKEN')
 
     parser = argparse.ArgumentParser(
@@ -237,3 +239,7 @@ Delete a PR
     gh = Github(args['token'])
     if not args['numberonly'] and not args['noratelimit']:
         print "Github Rate Limiting: %d remaining of max %d" % (gh.rate_limiting[0], gh.rate_limiting[1])
+
+if __name__ == '__main__':
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,16 @@ github-pr setup
 from setuptools import setup
 
 setup(
-    name='github-pr',
+    name='github_pr',
     author='DataXu',
     author_email='mferrante@dataxu.com',
     description='Pull Request utility script',
     license='(c) Copyright 2015. DataXu, Inc. All Rights Reserved.',
+    entry_points={
+        'console_scripts': [
+            'github-pr = github_pr:main',
+        ]
+    },
     install_requires=[
         'argparse==1.3.0',
         'PyGithub==1.25.2',
@@ -26,6 +31,6 @@ setup(
     ],
     url='https://github.com/dataxu/github-pr',
     version='1.1.1',
-    scripts=['github-pr'],
+    scripts=['github_pr.py'],
     keywords=['github'],
 )


### PR DESCRIPTION
@ferrants I've tested that the pip install works and I can still call the script with "github-pr", but these changes should let other scripts include github_pr as a module.